### PR TITLE
Add Github action CI workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: ci
+on:
+  push:
+    branches:      
+      - '**'
+  pull_request:
+jobs:
+  ci:
+    uses: lunarway/lw-shuttle-go-lib-plan/.github/workflows/plan-ci.yml@stable
+    secrets: inherit
+    with:
+      lifecycle: stable


### PR DESCRIPTION
This change adds a dagger CI pipeline that will run the full CI flow via dagger.io

[_Created by Sourcegraph batch change `mah/go-library-gh-actions-dagger`._](https://lunar.sourcegraph.com/users/mah/batch-changes/go-library-gh-actions-dagger)